### PR TITLE
add feature to render specific static frame 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-.DS_Store
-.vscode
-build
-*.egg-info


### PR DESCRIPTION
```python
    def create_frame_view(self, grid_holder):
        gh: GridHolder = grid_holder
        frame_idx = gh.config.frame_idx
        gh.history = [[agent_states[gh.config.frame_idx]] for agent_states in gh.history]
```
By add frame_idx definition and create_frame_view, we can render specific frame and the use of frame_idx are valid when `static=True`
Below are some code to see the feature:
```python
from pogema import pogema_v0, GridConfig, AnimationMonitor, AnimationConfig

# Define random configuration
grid_config = GridConfig(num_agents=64,  # number of agents
						 size=32, # size of the grid
						 density=0.4,  # obstacle density
						 seed=1,  # set to None for random
								  # obstacles, agents and targets
								  # positions at each reset
						 max_episode_steps=50,  # horizon
						 obs_radius=1,  # defines field of view
						 )

env = pogema_v0(grid_config=grid_config)
env = AnimationMonitor(env)
obs, info = env.reset()
env.render()


terminated = truncated = [False, ...]

while not all(terminated) and not all(truncated):
	# Use random policy to make actions
	obs, reward, terminated, truncated, info = env.step([env.action_space.sample() for _ in range(grid_config.num_agents)])
env.render()

```
```python
from IPython.display import SVG, display
env.save_animation("render.svg", AnimationConfig(frame_idx=5, static=False))
display(SVG('render.svg'))
```
```python
from IPython.display import SVG, display
env.save_animation("render.svg", AnimationConfig(frame_idx=15,static=True))
display(SVG('render.svg'))
```
```python
from IPython.display import SVG, display
env.save_animation("render.svg", AnimationConfig(egocentric_idx=2,frame_idx=10,static=True))
display(SVG('render.svg'))
```